### PR TITLE
Fix build due to composition api failing on linux

### DIFF
--- a/frontend/src/components/atoms/ChoppaLogoAtom.vue
+++ b/frontend/src/components/atoms/ChoppaLogoAtom.vue
@@ -2,9 +2,11 @@
 <font-awesome icon="helicopter" :class="[ this.css ]" />
 </template>
 
-<script setup="props" lang="ts">
-declare const props: { //eslint-disable-line no-unused-vars
-  css: string
+<script lang="ts">
+export default {
+  props: {
+    css: String
+  }
 };
 </script>
 


### PR DESCRIPTION
Reverted ChoppaLogoAtom to vue2 component api due to the vue compiler failing due to a Heroku/Linux issue.